### PR TITLE
Upgrade to support a Kubernetes nginx deployment and run as non-root

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "tests/test_helpers/bats-support"]
+	path = tests/test_helpers/bats-support
+	url = https://github.com/bats-core/bats-support.git
+[submodule "tests/test_helpers/bats-assert"]
+	path = tests/test_helpers/bats-assert
+	url = https://github.com/bats-core/bats-assert.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,13 @@ RUN set -x \
   ;
 
 RUN apk update \
-  && apk add --no-cache bash git nginx aws-cli \
+  && apk add --no-cache bash tree git nginx aws-cli \
   && cd /etc/nginx \
   && mkdir -p /run/nginx /var/www/html \
+  && ln -s /dev/stdout /var/log/nginx/access.log \
+  && ln -s /dev/stderr /var/log/nginx/error.log \
+  && chown nginx:nginx /etc/nginx/http.d \
+  && chown nginx:nginx /var/www/html \
   ;
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
@@ -51,5 +55,7 @@ ENTRYPOINT ["/entry.sh"]
 
 EXPOSE 80
 STOPSIGNAL SIGTERM
+
+USER nginx
 
 CMD ["nginx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY *.sh /
 
 ENTRYPOINT ["/entry.sh"]
 
-EXPOSE 80
+EXPOSE 8080
 STOPSIGNAL SIGTERM
 
 USER nginx

--- a/default.conf.tmpl
+++ b/default.conf.tmpl
@@ -1,6 +1,6 @@
 server {
-	listen 80 default_server;
-	listen [::]:80 default_server;
+	listen {{env.Getenv "PORT" "8080"}} default_server;
+	listen [::]:{{env.Getenv "PORT" "8080"}} default_server;
 
 	index {{.Env.NGINX_SERVER_INDEX}};
 	root  {{.Env.NGINX_SERVER_ROOT}};

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ ADD . .
 # Build the site using yarn
 RUN yarn install --pure-lockfile --ignore-optional --no-progress
 
-FROM panubo/staticsite:latest
+FROM quay.io/panubo/staticsite:latest
 
 # Copy build artefacts to staticsite image
 COPY --from=build --chown=nginx:nginx /usr/src/app/dist /var/www/html

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ RUN yarn install --pure-lockfile --ignore-optional --no-progress
 FROM panubo/staticsite:latest
 
 # Copy build artefacts to staticsite image
-COPY --from=build /usr/src/app/dist /var/www/html
+COPY --from=build --chown=nginx:nginx /usr/src/app/dist /var/www/html
 
 WORKDIR /var/www/html
 

--- a/docs/example/Dockerfile
+++ b/docs/example/Dockerfile
@@ -10,7 +10,7 @@ ADD . .
 # Build the site using yarn
 RUN yarn install --pure-lockfile --ignore-optional --no-progress
 
-FROM panubo/staticsite:latest
+FROM quay.io/panubo/staticsite:latest
 
 # Copy build artefacts to staticsite image
 COPY --from=build --chown=nginx:nginx /usr/src/app/dist /var/www/html

--- a/docs/example/Dockerfile
+++ b/docs/example/Dockerfile
@@ -13,7 +13,7 @@ RUN yarn install --pure-lockfile --ignore-optional --no-progress
 FROM panubo/staticsite:latest
 
 # Copy build artefacts to staticsite image
-# COPY --from=build /usr/src/app/dist /var/www/html
+COPY --from=build --chown=nginx:nginx /usr/src/app/dist /var/www/html
 
 WORKDIR /var/www/html
 

--- a/entry.sh
+++ b/entry.sh
@@ -14,17 +14,23 @@ export NGINX_SINGLE_PAGE_INDEX=${NGINX_SINGLE_PAGE_INDEX:-'index.html'}
 export DEPLOYFILE_PRE=${DEPLOYFILE_PRE:-'/Deployfile.pre'}
 export DEPLOYFILE_POST=${DEPLOYFILE_POST:-'/Deployfile.post'}
 
-echo "> Running templater"
-/templater.sh
+templater() {
+  echo "> Running templater"
+  /templater.sh
+}
+
+deployfile_pre() {
+  if [[ -f "${DEPLOYFILE_PRE}" ]] && [[ "${RUN_DEPLOYFILE_COMMANDS:-}" == 'true' ]]; then
+    echo "> Running all commands in ${DEPLOYFILE_PRE}"
+    run_all "${DEPLOYFILE_PRE}"
+  fi
+}
 
 echo "> Entrypoint command:" "${@}"
 
-if [[ -f "${DEPLOYFILE_PRE}" ]] && [[ "${RUN_DEPLOYFILE_COMMANDS:-}" == 'true' ]]; then
-  echo "> Running all commands in ${DEPLOYFILE_PRE}"
-  run_all "${DEPLOYFILE_PRE}"
-fi
-
 if [[ "${1}" == "s3sync" ]]; then
+  templater
+  deployfile_pre
   echo "> Running s3sync"
   /s3sync.sh
   if [[ -f "${DEPLOYFILE_POST}" ]] && [[ "${RUN_DEPLOYFILE_COMMANDS:-}" == 'true' ]]; then
@@ -32,9 +38,18 @@ if [[ "${1}" == "s3sync" ]]; then
     run_all "${DEPLOYFILE_POST}"
   fi
 elif [[ "${1}" == "nginx" ]]; then
+  templater
+  deployfile_pre
   echo "> Running nginx"
   render_templates /etc/nginx/http.d/default.conf.tmpl
   nginx
+elif [[ "${1}" == "k8s-nginx" ]]; then
+  echo "> Running nginx"
+  nginx
+elif [[ "${1}" == "k8s-init" ]]; then
+  echo "> Running Kubernetes template script"
+  /k8s-init.sh
+  exit
 else
   if [[ "$1" != "" ]]; then
     exec "${@}"

--- a/k8s-init.sh
+++ b/k8s-init.sh
@@ -5,6 +5,8 @@
 # The /volume mount should then be mounted into the main container as
 # readOnly mounts and using `k8s-nginx` as the command.
 
+K8S_VOLUME_PATH="${K8S_VOLUME_PATH:=/volume}"
+
 source /panubo-functions.sh
 
 set -euo pipefail
@@ -12,16 +14,14 @@ IFS=$'\n\t'
 
 [[ "${DEBUG:-}" == 'true' ]] && set -x
 
-ls -la /
+mkdir "${K8S_VOLUME_PATH}/config"
+mkdir "${K8S_VOLUME_PATH}/content"
 
-mkdir /volume/config
-mkdir /volume/content
-
-cp -a /etc/nginx/http.d /volume/config
-cp -a "${NGINX_SERVER_ROOT}" /volume/content
+cp -a /etc/nginx/http.d "${K8S_VOLUME_PATH}/config"
+cp -a "${NGINX_SERVER_ROOT}" "${K8S_VOLUME_PATH}/content"
 
 export OLD_NGINX_SERVER_ROOT="${NGINX_SERVER_ROOT}"
-export NGINX_SERVER_ROOT=/volume/content/html
+export NGINX_SERVER_ROOT=${K8S_VOLUME_PATH}/content/html
 /templater.sh
 
-render_templates /volume/config/http.d/default.conf.tmpl
+render_templates "${K8S_VOLUME_PATH}/config/http.d/default.conf.tmpl"

--- a/k8s-init.sh
+++ b/k8s-init.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This script will copy the nginx config and html content to /volume then run
+# the normal renderers. This is used in an initContainer in a Kubernetes pod.
+# The /volume mount should then be mounted into the main container as
+# readOnly mounts and using `k8s-nginx` as the command.
+
+source /panubo-functions.sh
+
+set -euo pipefail
+IFS=$'\n\t'
+
+[[ "${DEBUG:-}" == 'true' ]] && set -x
+
+ls -la /
+
+mkdir /volume/config
+mkdir /volume/content
+
+cp -a /etc/nginx/http.d /volume/config
+cp -a "${NGINX_SERVER_ROOT}" /volume/content
+
+export OLD_NGINX_SERVER_ROOT="${NGINX_SERVER_ROOT}"
+export NGINX_SERVER_ROOT=/volume/content/html
+/templater.sh
+
+render_templates /volume/config/http.d/default.conf.tmpl

--- a/templater.sh
+++ b/templater.sh
@@ -9,10 +9,12 @@ IFS=$'\n\t'
 
 # render templates when set
 while read -r line; do
-  echo ">> Running templater on ${line#*\=}"
+  newline="${line#*\=}"
+  echo ">> Running templater on ${newline}"
   (
     # relative paths to server root
     cd "${NGINX_SERVER_ROOT}"
-    render_templates "${line#*\=}"
+    # render templates and replace any full paths if OLD_NGINX_SERVER_ROOT is set (set by k8s-init.sh)
+    render_templates "${newline/${OLD_NGINX_SERVER_ROOT:-}/${NGINX_SERVER_ROOT}}"
   )
 done < <(env | grep "^RENDER_TEMPLATE")

--- a/tests/html/v1/Dockerfile
+++ b/tests/html/v1/Dockerfile
@@ -5,6 +5,8 @@ ENV \
   CACHE_CONTROL_OVERRIDE_INDEX="index.html" \
   CACHE_CONTROL_OVERRIDE_404="404.html" \
   CACHE_CONTROL_DEFAULT_OVERRIDE="public, max-age=60, s-maxage=60" \
-  CACHE_CONTROL_OVERRIDE_SPECIAL="special-cache.html:public, max-age=600"
+  CACHE_CONTROL_OVERRIDE_SPECIAL="special-cache.html:public, max-age=600" \
+  RENDER_TEMPLATE_ENV_CONFIG=/var/www/html/env-config.js.tmpl \
+  RENDER_TEMPLATE_ENV_CONFIG2=env-config2.js.tmpl
 
-COPY . /var/www/html
+COPY --chown=nginx:nginx . /var/www/html

--- a/tests/html/v1/env-config.js.tmpl
+++ b/tests/html/v1/env-config.js.tmpl
@@ -1,0 +1,3 @@
+window._env_ = {
+    "hostname": "{{ env.Getenv "HOSTNAME" }}",
+}

--- a/tests/html/v1/env-config2.js.tmpl
+++ b/tests/html/v1/env-config2.js.tmpl
@@ -1,0 +1,3 @@
+window._env_ = {
+    "hostname": "{{ env.Getenv "HOSTNAME" }}",
+}

--- a/tests/html/v2/Dockerfile
+++ b/tests/html/v2/Dockerfile
@@ -11,3 +11,7 @@ ENV \
   CACHE_CONTROL_OVERRIDE_CACHED_JSON="cached-json:public, max-age=1200"
 
 COPY . /var/www/html
+
+USER root
+RUN chown -R nginx:nginx /var/www/html
+USER nginx

--- a/tests/k8s.bats
+++ b/tests/k8s.bats
@@ -1,0 +1,56 @@
+load test_helpers/bats-support/load
+load test_helpers/bats-assert/load
+load functions.bash
+# load setup.bash
+
+setup_file() {
+	# Disable parallel execution in this file
+	export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+	docker_volume="$(docker volume create)"
+
+	export docker_volume
+}
+
+teardown_file() {
+	docker volume rm -f "${docker_volume}" || true
+}
+
+@test "k8s-init" {
+	# Fix volume permissions to match K8s behaviour
+	docker run --rm -v "${docker_volume}:/volume" busybox install -d -o root -g 2000 -m 2775 /volume
+
+	# Run k8s-init - content and config should be copied to the volume
+	docker run --rm -v "${docker_volume}:/volume" --group-add 2000 panubo/staticsite-testsite:1 k8s-init
+
+	# Print the content of the volume
+	run docker run --rm -v "${docker_volume}:/volume" busybox sh -c 'find /volume | sort'
+
+	# diag "${output}"
+	assert_line '/volume/config/http.d/default.conf'
+	assert_line '/volume/content/html/env-config.js'
+	assert_line '/volume/content/html/env-config2.js'
+
+	# assert_output --regexp '/volume/config/http\.d/default\.conf[^.]'
+	# assert_output --regexp '/volume/content/html/env-config\.js[^.]'
+	# assert_output --regexp '/volume/content/html/env-config2\.js[^.]'
+}
+
+@test "k8s-nginx" {
+	# This test isn't possible with docker since your cannot mount a subPath
+	# from a docker volume. eg `-v "$
+	# {docker_volume}/config/http.d:/etc/nginx/http.d:ro` (or whatever the
+	# syntax will be if implemented in docker).
+	skip "Unable to implement with docker, missing subPath support"
+
+	container="$(docker run -d -v "${docker_volume}:/volume:ro" --group-add 2000 -p 8080 panubo/staticsite-testsite:1 k8s-nginx)"
+	container_ip="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${container})"
+	container_http_port="$(docker inspect --format '{{(index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort}}' ${container} || { docker logs ${container} >&3 2>&3; return 1; })"
+	( wait_http "http://127.0.0.1:${container_http_port}"; )
+
+	run curl -sSf http://127.0.0.1:${container_http_port}
+
+	docker rm -f "${container}" || true
+
+	assert_success
+}

--- a/tests/s3-rollback.bats
+++ b/tests/s3-rollback.bats
@@ -1,3 +1,5 @@
+load test_helpers/bats-support/load
+load test_helpers/bats-assert/load
 load functions.bash
 # load setup.bash
 
@@ -51,8 +53,8 @@ teardown_file() {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/index.html
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "<p>v1</p>" <<<"${output}"
+	assert_success
+	assert_line "<p>v1</p>"
 }
 
 @test "s3-rollback upload v2" {
@@ -69,8 +71,8 @@ teardown_file() {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/index.html
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "<p>v2</p>" <<<"${output}"
+	assert_success
+	assert_line "<p>v2</p>"
 }
 
 @test "s3-rollback rollback to v1" {
@@ -87,6 +89,6 @@ teardown_file() {
 	run curl -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/index.html
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "<p>v1</p>" <<<"${output}"
+	assert_success
+	assert_line "<p>v1</p>"
 }

--- a/tests/s3-upgrade.bats
+++ b/tests/s3-upgrade.bats
@@ -1,3 +1,5 @@
+load test_helpers/bats-support/load
+load test_helpers/bats-assert/load
 load functions.bash
 # load setup.bash
 
@@ -52,8 +54,8 @@ teardown_file() {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/special-cache.html
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "Cache-Control: public, max-age=600" <<<"${output}"
+	assert_success
+	assert_line -p 'Cache-Control: public, max-age=600'
 }
 
 # `no-mime-json` is the same file between versions, it does not have a standard extension so automatic mime type detection doesn't work
@@ -63,8 +65,8 @@ teardown_file() {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/no-mime-json
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "Content-Type: binary/octet-stream" <<<"${output}"
+	assert_success
+	assert_line -p 'Content-Type: binary/octet-stream'
 }
 
 # `cached-json` is the same file between versions, it does not have a standard extension so automatic mime type detection doesn't work
@@ -74,9 +76,9 @@ teardown_file() {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/cached-json
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "Cache-Control: public, max-age=3600" <<<"${output}"
-	grep "Content-Type: binary/octet-stream" <<<"${output}"
+	assert_success
+	assert_line -p 'Cache-Control: public, max-age=3600'
+	assert_line -p 'Content-Type: binary/octet-stream'
 }
 
 @test "s3-upgrade upload v2" {
@@ -89,23 +91,23 @@ teardown_file() {
 		panubo/staticsite-testsite:2 s3sync
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
+	assert_success
 }
 
 @test "s3-upgrade check file specific cache after upgrade" {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/special-cache.html
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "Cache-Control: public, max-age=1200" <<<"${output}"
+	assert_success
+	assert_line -p 'Cache-Control: public, max-age=1200'
 }
 
 @test "s3-upgrade check no-mime-json content-type after upgrade" {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/no-mime-json
 	# diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "Content-Type: application/json" <<<"${output}"
+	assert_success
+	assert_line -p 'Content-Type: application/json'
 }
 
 @test "s3-upgrade check cached-json content-type and cache-control after upgrade" {
@@ -113,7 +115,7 @@ teardown_file() {
 	run curl -i -sSf http://127.0.0.1:${minio_container_http_port}/test-bucket/cached-json
 	diag "${output}"
 
-	[[ "${status}" -eq 0 ]]
-	grep "Cache-Control: public, max-age=1200" <<<"${output}"
-	grep "Content-Type: application/json" <<<"${output}"
+	assert_success
+	assert_line -p 'Cache-Control: public, max-age=1200'
+	assert_line -p 'Content-Type: application/json'
 }


### PR DESCRIPTION
Includes
* Container runs as `nginx` user
* Nginx logs to stdout/stderr
* Nginx port defaults to 8080 and is configurable with PORT env
* Add README notes about changes
* Update examples
* Add k8s-init and k8s-nginx entrypoints, some entry.sh rework
* Add k8s-init.sh script to perform templating and copy to a volume
* Add support to templater.sh to update path when given path is not relative to the nginx root
* Add k8s tests
* Add test to check env-config.js templating
* Switch test to use bats-asset help functions